### PR TITLE
feat: add Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16
+
+WORKDIR $GOPATH/src/github.com/edoardottt/scilla
+
+COPY . .
+RUN go install -v ./...
+RUN mv ./lists/ /usr/bin/
+
+ENTRYPOINT ["scilla"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Preview :bar_chart:
 Installation 📡
 ----------
 
+### Using Docker
+
+```shell
+docker build -t scilla .
+docker run scilla help
+```
+
+### Building from source
+
 You need [Go](https://golang.org/).
 
 - **Linux**


### PR DESCRIPTION
I've added a simple Dockerfile, so that users may run scilla on any platform without building it from the source.