### PR TITLE
Fix typo in make.bat command for go build on windows

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -74,7 +74,7 @@ set GOOS=windows
 set GOARCH=amd64
 set GO111MODULE=on
 set CGO_ENABLED=0
-go build go build ./cmd/scilla
+go build ./cmd/scilla
 echo Create keys.yaml file and add your keys there if you need them.
 echo See https://github.com/edoardottt/scilla/wiki/Installation
 echo Done.


### PR DESCRIPTION
Hi,

There is a type in the go build command for windows in the make.bat file.

The "go build" command is repeated twice.

Here is the fix.