### PR TITLE
feature: adding subdomain center as source

### DIFF
--- a/pkg/opendb/subdomaincenter.go
+++ b/pkg/opendb/subdomaincenter.go
@@ -1,0 +1,70 @@
+/*
+
+=======================
+Scilla - Information Gathering Tool
+=======================
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see http://www.gnu.org/licenses/.
+
+	@Repository:  https://github.com/edoardottt/scilla
+
+	@Author:      edoardottt, https://www.edoardoottavianelli.it
+
+	@License: https://github.com/edoardottt/scilla/blob/main/LICENSE
+
+*/
+
+package opendb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	httpUtils "github.com/edoardottt/scilla/internal/http"
+)
+
+// SubdomainCenter retrieves from the url below some known subdomains.
+func SubdomainCenter(domain string, plain bool) []string {
+	if !plain {
+		fmt.Println("Pulling data from ThreatCrowd")
+	}
+
+	client := http.Client{
+		Timeout: httpUtils.Seconds30,
+	}
+	result := make([]string, 0)
+	url := "http://api.subdomain.center/?domain=" + domain
+	wrapper := struct {
+		Records []string `json:"subdomains"`
+	}{}
+	resp, err := client.Get(url)
+
+	if err != nil {
+		return result
+	}
+
+	defer resp.Body.Close()
+
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&wrapper)
+
+	if err != nil {
+		return result
+	}
+
+	result = append(result, wrapper.Records...)
+
+	return result
+}

--- a/pkg/opendb/subdomaincenter.go
+++ b/pkg/opendb/subdomaincenter.go
@@ -37,9 +37,9 @@ import (
 )
 
 // SubdomainCenter retrieves from the url below some known subdomains.
-func SubdomainCenter(domain string, plain bool) []string {
+func SubdomainCenterSubdomains(domain string, plain bool) []string {
 	if !plain {
-		fmt.Println("Pulling data from Subdomain")
+		fmt.Println("Pulling data from Subdomain Center")
 	}
 
 	client := http.Client{
@@ -64,6 +64,7 @@ func SubdomainCenter(domain string, plain bool) []string {
 	// Decode the response body as list of string
 	var response []string
 	err = json.Unmarshal(body, &response)
+
 	if err != nil {
 		return result
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -188,6 +188,10 @@ func ReportSubcommandHandler(userInput input.Input, mutex *sync.Mutex,
 		// sonar := opendb.SonarSubdomains(urlUtils.CleanProtocol(target), false)
 		// subdomains = opendb.AppendDBSubdomains(sonar, subdomains)
 
+		// Service not working
+		// subdomaincenter := opendb.SubdomainCenterSubdomains(urlUtils.CleanProtocol(target), false)
+		// subdomains = opendb.AppendDBSubdomains(subdomaincenter, subdomains)
+
 		if userInput.ReportVirusTotal {
 			vtSubs := opendb.VirusTotalSubdomains(urlUtils.CleanProtocol(target), input.GetVirusTotalKey(), false)
 			subdomains = opendb.AppendDBSubdomains(vtSubs, subdomains)
@@ -364,6 +368,10 @@ func SubdomainSubcommandHandler(userInput input.Input, mutex *sync.Mutex,
 		// Service not working
 		// sonar := opendb.SonarSubdomains(urlUtils.CleanProtocol(target), userInput.SubdomainPlain)
 		// subdomains = opendb.AppendDBSubdomains(sonar, subdomains)
+
+		// Service not working
+		// subdomaincenter := opendb.SubdomainCenterSubdomains(urlUtils.CleanProtocol(target), false)
+		// subdomains = opendb.AppendDBSubdomains(subdomaincenter, subdomains)
 
 		if userInput.SubdomainVirusTotal {
 			vtSubs := opendb.VirusTotalSubdomains(urlUtils.CleanProtocol(target), input.GetVirusTotalKey(),


### PR DESCRIPTION
This source returns the empty list for almost all the domains. The original [sourcecode](https://github.com/owasp-amass/amass/blob/5f1f7176bae60975c1e5be64273cb201f1bb37c3/resources/scripts/api/subdomaincenter.ads) has rate limiting (upto 2 request) as well.